### PR TITLE
Re-enable nightly builds for i9305 device

### DIFF
--- a/lineage-build-targets
+++ b/lineage-build-targets
@@ -72,6 +72,7 @@ huashan userdebug cm-14.1 W 3
 hydrogen userdebug cm-14.1 W 3
 i9100 userdebug cm-14.1 W 3
 i9300 userdebug cm-14.1 W 3
+i9305 userdebug cm-14.1 W 3
 ido userdebug cm-14.1 W 3
 ivy userdebug cm-14.1 W 3
 jag3gds userdebug cm-14.1 W 3


### PR DESCRIPTION
This device had been disabled in commit b2560ed989493a7798ca914fe82033ccfee610df because of https://jira.lineageos.org/browse/BUGBASH-1116, which has been fixed now.
Fixes https://jira.lineageos.org/browse/BUGBASH-1376